### PR TITLE
Fix scaling of outputs with derivative >= 2

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -32,4 +32,21 @@ describe('Savitzky–Golay test', function() {
     }
     expect(ans[0]).toBe(0);
   });
+
+  it('Second derivative test', function() {
+    let options = {
+      windowSize: 7,
+      derivative: 2,
+      polynomial: 3,
+    };
+    let data = new Array(100);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = Math.pow(i, 3) - 2 * Math.pow(i, 2);
+    }
+    let ans = savitzkyGolay(data, 1, options);
+    expect(ans).toHaveLength(94);
+    for (let j = 0; j < ans.length; j++) {
+      expect(ans[j]).toBeCloseTo(6 * (j + 3) - 4, 2);
+    }
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,18 @@
 import { Matrix, MatrixTransposeView, inverse } from 'ml-matrix';
 import padArray from 'ml-pad-array';
 
+/**
+ * Factorial of a number
+ * @ignore
+ * @param n
+ * @return {number}
+ */
+function factorial(n) {
+  let r = 1;
+  while (n > 0) r *= n--;
+  return r;
+}
+
 const defaultOptions = {
   windowSize: 5,
   derivative: 1,
@@ -67,7 +79,7 @@ export default function savitzkyGolay(data, h, options) {
     let Jinv = inverse(Jtranspose.mmul(J));
     C = Jinv.mmul(Jtranspose);
     C = C.getRow(options.derivative);
-    norm = 1;
+    norm = 1 / factorial(options.derivative);
   }
   let det = norm * Math.pow(h, options.derivative);
   for (let k = step; k < data.length - step; k++) {


### PR DESCRIPTION
Adds a second-derivative test which v4.1.0 fails, and fixes the bug responsible.

The coefficients from differentiation (e.g. the 6 in d^2/dx^2(x^3) = 6x) were not being correctly accounted for. This had been addressed [on the `development` branch](https://github.com/mljs/savitzky-golay/blob/c41c178516c36fcd4f5363c377ec8e46250a08a1/src/index.js#L102) (although the saved [`divisor = 7`](https://github.com/mljs/savitzky-golay/blob/c41c178516c36fcd4f5363c377ec8e46250a08a1/src/index.js#L71) should have been changed to 14 in that case).

The returned values are multiplied by `factorial(options.derivative)` relative to v4.1.0, except when `windowSize==5`, `polynomial==2`, and `derivative==2` (which were already correct thanks to the saved [`C` and `norm`](https://github.com/mljs/savitzky-golay/blob/19ba266745fb2562408968a48359367a52789ea0/src/index.js#L54)).